### PR TITLE
feat: add log

### DIFF
--- a/dblockdevice.cpp
+++ b/dblockdevice.cpp
@@ -6,16 +6,18 @@
 #include "private/dblockdevice_p.h"
 #include "udisks2_interface.h"
 #include "objectmanager_interface.h"
+#include <QDebug>
 
 DBlockDevicePrivate::DBlockDevicePrivate(DBlockDevice *qq)
     : q_ptr(qq)
 {
-
+    qDebug() << "Creating DBlockDevicePrivate";
 }
 
 void DBlockDevice::onInterfacesAdded(const QDBusObjectPath &object_path, const QMap<QString, QVariantMap> &interfaces_and_properties)
 {
     Q_D(DBlockDevice);
+    qDebug() << "Interfaces added for block device:" << object_path.path();
 
     const QString &path = object_path.path();
 
@@ -23,14 +25,17 @@ void DBlockDevice::onInterfacesAdded(const QDBusObjectPath &object_path, const Q
         return;
 
     if (interfaces_and_properties.contains(QStringLiteral(UDISKS2_SERVICE ".Filesystem"))) {
+        qDebug() << "Filesystem interface added for block device:" << path;
         Q_EMIT hasFileSystemChanged(true);
     }
 
     if (interfaces_and_properties.contains(QStringLiteral(UDISKS2_SERVICE ".Partition"))) {
+        qDebug() << "Partition interface added for block device:" << path;
         Q_EMIT hasPartitionChanged(true);
     }
 
     if (interfaces_and_properties.contains(QStringLiteral(UDISKS2_SERVICE ".Encrypted"))) {
+        qDebug() << "Encrypted interface added for block device:" << path;
         Q_EMIT isEncryptedChanged(true);
     }
 }
@@ -38,6 +43,7 @@ void DBlockDevice::onInterfacesAdded(const QDBusObjectPath &object_path, const Q
 void DBlockDevice::onInterfacesRemoved(const QDBusObjectPath &object_path, const QStringList &interfaces)
 {
     Q_D(DBlockDevice);
+    qDebug() << "Interfaces removed for block device:" << object_path.path();
 
     const QString &path = object_path.path();
 
@@ -46,10 +52,13 @@ void DBlockDevice::onInterfacesRemoved(const QDBusObjectPath &object_path, const
 
     for (const QString &i : interfaces) {
         if (i == QStringLiteral(UDISKS2_SERVICE ".Filesystem")) {
+            qDebug() << "Filesystem interface removed for block device:" << path;
             Q_EMIT hasFileSystemChanged(false);
         } else if (i == QStringLiteral(UDISKS2_SERVICE ".Partition")) {
+            qDebug() << "Partition interface removed for block device:" << path;
             Q_EMIT hasPartitionChanged(false);
         } else if (i == QStringLiteral(UDISKS2_SERVICE ".Encrypted")) {
+            qDebug() << "Encrypted interface removed for block device:" << path;
             Q_EMIT isEncryptedChanged(false);
         }
     }
@@ -57,11 +66,14 @@ void DBlockDevice::onInterfacesRemoved(const QDBusObjectPath &object_path, const
 
 void DBlockDevice::onPropertiesChanged(const QString &interface, const QVariantMap &changed_properties)
 {
+    qDebug() << "Properties changed for block device:" << d_ptr->dbus->path() << "interface:" << interface;
+
     if (interface.endsWith(".PartitionTable")) {
         auto begin = changed_properties.begin();
 
         while (begin != changed_properties.constEnd()) {
             if (begin.key() == "Type") {
+                qDebug() << "Partition table type changed for block device:" << d_ptr->dbus->path();
                 Q_EMIT ptTypeChanged();
                 break;
             }
@@ -97,20 +109,20 @@ void DBlockDevice::onPropertiesChanged(const QString &interface, const QVariantM
 
 DBlockDevice::~DBlockDevice()
 {
-
+    qDebug() << "DBlockDevice destroyed:" << path();
 }
 
 bool DBlockDevice::isValid() const
 {
     Q_D(const DBlockDevice);
-
+    qDebug() << "Checking if block device is valid:" << d->dbus->path();
     return d->dbus->isValid();
 }
 
 bool DBlockDevice::watchChanges() const
 {
     Q_D(const DBlockDevice);
-
+    qDebug() << "Getting block device watch changes status:" << d->dbus->path();
     return d->watchChanges;
 }
 
@@ -122,21 +134,21 @@ bool DBlockDevice::watchChanges() const
 QString DBlockDevice::path() const
 {
     Q_D(const DBlockDevice);
-
+    qDebug() << "Getting block device path:" << d->dbus->path();
     return d->dbus->path();
 }
 
 QList<QPair<QString, QVariantMap> > DBlockDevice::configuration() const
 {
     Q_D(const DBlockDevice);
-
+    qDebug() << "Getting block device configuration:" << d->dbus->path();
     return d->dbus->configuration();
 }
 
 QString DBlockDevice::cryptoBackingDevice() const
 {
     Q_D(const DBlockDevice);
-
+    qDebug() << "Getting block device crypto backing device:" << d->dbus->path();
     return d->dbus->cryptoBackingDevice().path();
 }
 
@@ -148,14 +160,14 @@ QString DBlockDevice::cryptoBackingDevice() const
 QByteArray DBlockDevice::device() const
 {
     Q_D(const DBlockDevice);
-
+    qDebug() << "Getting block device device path:" << d->dbus->path();
     return d->dbus->device();
 }
 
 qulonglong DBlockDevice::deviceNumber() const
 {
     Q_D(const DBlockDevice);
-
+    qDebug() << "Getting block device number:" << d->dbus->path();
     return d->dbus->deviceNumber();
 }
 
@@ -167,86 +179,89 @@ qulonglong DBlockDevice::deviceNumber() const
 QString DBlockDevice::drive() const
 {
     Q_D(const DBlockDevice);
-
+    qDebug() << "Getting block device drive path:" << d->dbus->path();
     return d->dbus->drive().path();
 }
 
 bool DBlockDevice::hintAuto() const
 {
     Q_D(const DBlockDevice);
-
+    qDebug() << "Getting block device hint auto:" << d->dbus->path();
     return d->dbus->hintAuto();
 }
 
 QString DBlockDevice::hintIconName() const
 {
     Q_D(const DBlockDevice);
-
+    qDebug() << "Getting block device hint icon name:" << d->dbus->path();
     return d->dbus->hintIconName();
 }
 
 bool DBlockDevice::hintIgnore() const
 {
     Q_D(const DBlockDevice);
-
+    qDebug() << "Getting block device hint ignore:" << d->dbus->path();
     return d->dbus->hintIgnore();
 }
 
 QString DBlockDevice::hintName() const
 {
     Q_D(const DBlockDevice);
-
+    qDebug() << "Getting block device hint name:" << d->dbus->path();
     return d->dbus->hintName();
 }
 
 bool DBlockDevice::hintPartitionable() const
 {
     Q_D(const DBlockDevice);
-
+    qDebug() << "Getting block device hint partitionable:" << d->dbus->path();
     return d->dbus->hintPartitionable();
 }
 
 QString DBlockDevice::hintSymbolicIconName() const
 {
     Q_D(const DBlockDevice);
-
+    qDebug() << "Getting block device hint symbolic icon name:" << d->dbus->path();
     return d->dbus->hintSymbolicIconName();
 }
 
 bool DBlockDevice::hintSystem() const
 {
     Q_D(const DBlockDevice);
-
+    qDebug() << "Getting block device hint system:" << d->dbus->path();
     return d->dbus->hintSystem();
 }
 
 QString DBlockDevice::id() const
 {
     Q_D(const DBlockDevice);
-
+    qDebug() << "Getting block device ID:" << d->dbus->path();
     return d->dbus->id();
 }
 
 QString DBlockDevice::idLabel() const
 {
     Q_D(const DBlockDevice);
-
+    qDebug() << "Getting block device ID label:" << d->dbus->path();
     return d->dbus->idLabel();
 }
 
 QString DBlockDevice::idType() const
 {
     Q_D(const DBlockDevice);
-
+    qDebug() << "Getting block device ID type:" << d->dbus->path();
     return d->dbus->idType();
 }
 
 DBlockDevice::FSType DBlockDevice::fsType() const
 {
     const QString &fs_type = idType();
+    qDebug() << "Getting block device filesystem type:" << path() << "type:" << fs_type;
 
-    if (fs_type.isEmpty())
+    if (fs_type.isEmpty()) {
+        qWarning() << "Filesystem type is empty:" << path();
         return InvalidFS;
+    }
 
     if (fs_type == "hfs+")
         return hfs_plus;
@@ -257,6 +272,7 @@ DBlockDevice::FSType DBlockDevice::fsType() const
     int value = me.keyToValue(fs_type.toLatin1().constData(), &ok);
 
     if (!ok) {
+        qWarning() << "Failed to convert filesystem type:" << path() << "type:" << fs_type;
         return UnknowFS;
     }
 

--- a/dblockpartition.cpp
+++ b/dblockpartition.cpp
@@ -5,6 +5,7 @@
 #include "dblockpartition.h"
 #include "private/dblockdevice_p.h"
 #include "udisks2_interface.h"
+#include <QDebug>
 
 class DBlockPartitionPrivate : public DBlockDevicePrivate
 {
@@ -17,75 +18,76 @@ public:
 DBlockPartitionPrivate::DBlockPartitionPrivate(DBlockPartition *qq)
     : DBlockDevicePrivate(qq)
 {
-
+    qDebug() << "Creating DBlockPartitionPrivate";
 }
 
 qulonglong DBlockPartition::flags() const
 {
     Q_D(const DBlockPartition);
-
+    qDebug() << "Getting partition flags:" << d->dbus->path();
     return d->dbus->flags();
 }
 
 bool DBlockPartition::isContained() const
 {
     Q_D(const DBlockPartition);
-
+    qDebug() << "Checking if partition is contained:" << d->dbus->path();
     return d->dbus->isContained();
 }
 
 bool DBlockPartition::isContainer() const
 {
     Q_D(const DBlockPartition);
-
+    qDebug() << "Checking if partition is container:" << d->dbus->path();
     return d->dbus->isContainer();
 }
 
 QString DBlockPartition::name() const
 {
     Q_D(const DBlockPartition);
-
+    qDebug() << "Getting partition name:" << d->dbus->path();
     return d->dbus->name();
 }
 
 uint DBlockPartition::number() const
 {
     Q_D(const DBlockPartition);
-
+    qDebug() << "Getting partition number:" << d->dbus->path();
     return d->dbus->number();
 }
 
 qulonglong DBlockPartition::offset() const
 {
     Q_D(const DBlockPartition);
-
+    qDebug() << "Getting partition offset:" << d->dbus->path();
     return d->dbus->offset();
 }
 
 qulonglong DBlockPartition::size() const
 {
     Q_D(const DBlockPartition);
-
+    qDebug() << "Getting partition size:" << d->dbus->path();
     return d->dbus->size();
 }
 
 QString DBlockPartition::table() const
 {
     Q_D(const DBlockPartition);
-
+    qDebug() << "Getting partition table:" << d->dbus->path();
     return d->dbus->table().path();
 }
 
 QString DBlockPartition::type() const
 {
     Q_D(const DBlockPartition);
-
+    qDebug() << "Getting partition type:" << d->dbus->path();
     return d->dbus->type();
 }
 
 DBlockPartition::Type DBlockPartition::eType() const
 {
     const QString &type = this->type();
+    qDebug() << "Getting partition enum type:" << path() << "type:" << type;
 
     if (type.isEmpty())
         return Empty;
@@ -94,6 +96,7 @@ DBlockPartition::Type DBlockPartition::eType() const
     int value = type.toInt(&ok, 16);
 
     if (!ok) {
+        qWarning() << "Invalid partition type:" << type;
         return Unknow;
     }
 
@@ -103,15 +106,17 @@ DBlockPartition::Type DBlockPartition::eType() const
 QString DBlockPartition::UUID() const
 {
     Q_D(const DBlockPartition);
-
+    qDebug() << "Getting partition UUID:" << d->dbus->path();
     return d->dbus->uUID();
 }
 
 DBlockPartition::GUIDType DBlockPartition::guidType() const
 {
+    qDebug() << "Getting partition GUID type:" << path();
     static QByteArrayList list;
 
     if (list.isEmpty()) {
+        qDebug() << "Initializing GUID type list";
         // None
         list << "00000000-0000-0000-0000-000000000000"
              << "024DEE41-33E7-11D3-9D69-0008C781F39F"
@@ -681,42 +686,64 @@ QString DBlockPartition::guidTypeDescription(GUIDType type)
 void DBlockPartition::deletePartition(const QVariantMap &options)
 {
     Q_D(DBlockPartition);
-
-    d->dbus->Delete(options);
+    qDebug() << "Deleting partition:" << d->dbus->path() << "options:" << options;
+    auto r = d->dbus->Delete(options);
+    r.waitForFinished();
+    if (r.isError()) {
+        qWarning() << "Failed to delete partition:" << d->dbus->path() << "error:" << r.error().message();
+    }
 }
 
 void DBlockPartition::resize(qulonglong size, const QVariantMap &options)
 {
     Q_D(DBlockPartition);
-
-    d->dbus->Resize(size, options);
+    qDebug() << "Resizing partition:" << d->dbus->path() << "new size:" << size << "options:" << options;
+    auto r = d->dbus->Resize(size, options);
+    r.waitForFinished();
+    if (r.isError()) {
+        qWarning() << "Failed to resize partition:" << d->dbus->path() << "error:" << r.error().message();
+    }
 }
 
 void DBlockPartition::setFlags(qulonglong flags, const QVariantMap &options)
 {
     Q_D(DBlockPartition);
-
-    d->dbus->SetFlags(flags, options);
+    qDebug() << "Setting partition flags:" << d->dbus->path() << "flags:" << flags << "options:" << options;
+    auto r = d->dbus->SetFlags(flags, options);
+    r.waitForFinished();
+    if (r.isError()) {
+        qWarning() << "Failed to set partition flags:" << d->dbus->path() << "error:" << r.error().message();
+    }
 }
 
 void DBlockPartition::setName(const QString &name, const QVariantMap &options)
 {
     Q_D(DBlockPartition);
-
-    d->dbus->SetName(name, options);
+    qDebug() << "Setting partition name:" << d->dbus->path() << "new name:" << name << "options:" << options;
+    auto r = d->dbus->SetName(name, options);
+    r.waitForFinished();
+    if (r.isError()) {
+        qWarning() << "Failed to set partition name:" << d->dbus->path() << "error:" << r.error().message();
+    }
 }
 
 void DBlockPartition::setType(const QString &type, const QVariantMap &options)
 {
     Q_D(DBlockPartition);
-
-    d->dbus->SetType(type, options);
+    qDebug() << "Setting partition type:" << d->dbus->path() << "new type:" << type << "options:" << options;
+    auto r = d->dbus->SetType(type, options);
+    r.waitForFinished();
+    if (r.isError()) {
+        qWarning() << "Failed to set partition type:" << d->dbus->path() << "error:" << r.error().message();
+    }
 }
 
 void DBlockPartition::setType(DBlockPartition::Type type, const QVariantMap &options)
 {
-    if (type == Unknow)
+    if (type == Unknow) {
+        qWarning() << "Invalid partition type:" << type;
         return;
+    }
 
     QString type_string = QString::asprintf("0x%.2s", QByteArray::number(type, 16).constData());
 

--- a/ddiskdevice.cpp
+++ b/ddiskdevice.cpp
@@ -4,6 +4,7 @@
 
 #include "ddiskdevice.h"
 #include "udisks2_interface.h"
+#include <QDebug>
 
 class DDiskDevicePrivate
 {
@@ -16,195 +17,235 @@ DDiskDevice::DDiskDevice(const QString &path, QObject *parent)
     : QObject(parent)
     , d_ptr(new DDiskDevicePrivate())
 {
+    qDebug() << "Creating DDiskDevice for path:" << path;
     d_ptr->dbus = new OrgFreedesktopUDisks2DriveInterface(UDISKS2_SERVICE, path, QDBusConnection::systemBus(), this);
 }
 
 DDiskDevice::~DDiskDevice()
 {
-
+    qDebug() << "DDiskDevice destroyed:" << path();
 }
 
 QString DDiskDevice::path() const
 {
     Q_D(const DDiskDevice);
-
+    qDebug() << "Getting disk device path:" << d->dbus->path();
     return d->dbus->path();
 }
 
 bool DDiskDevice::canPowerOff() const
 {
+    qDebug() << "Checking if disk device can power off:" << path();
     return d_ptr->dbus->canPowerOff();
 }
 
 QVariantMap DDiskDevice::configuration() const
 {
+    qDebug() << "Getting disk device configuration:" << path();
     return d_ptr->dbus->configuration();
 }
 
 QString DDiskDevice::connectionBus() const
 {
+    qDebug() << "Getting disk device connection bus:" << path();
     return d_ptr->dbus->connectionBus();
 }
 
 bool DDiskDevice::ejectable() const
 {
+    qDebug() << "Checking if disk device is ejectable:" << path();
     return d_ptr->dbus->ejectable();
 }
 
 QString DDiskDevice::id() const
 {
+    qDebug() << "Getting disk device ID:" << path();
     return d_ptr->dbus->id();
 }
 
 QString DDiskDevice::media() const
 {
+    qDebug() << "Getting disk device media:" << path();
     return d_ptr->dbus->media();
 }
 
 bool DDiskDevice::mediaAvailable() const
 {
+    qDebug() << "Checking if disk device media is available:" << path();
     return d_ptr->dbus->mediaAvailable();
 }
 
 bool DDiskDevice::mediaChangeDetected() const
 {
+    qDebug() << "Checking if disk device media change is detected:" << path();
     return d_ptr->dbus->mediaChangeDetected();
 }
 
 QStringList DDiskDevice::mediaCompatibility() const
 {
+    qDebug() << "Getting disk device media compatibility:" << path();
     return d_ptr->dbus->mediaCompatibility();
 }
 
 bool DDiskDevice::mediaRemovable() const
 {
+    qDebug() << "Checking if disk device media is removable:" << path();
     return d_ptr->dbus->mediaRemovable();
 }
 
 QString DDiskDevice::model() const
 {
+    qDebug() << "Getting disk device model:" << path();
     return d_ptr->dbus->model();
 }
 
 bool DDiskDevice::optical() const
 {
+    qDebug() << "Checking if disk device is optical:" << path();
     return d_ptr->dbus->optical();
 }
 
 bool DDiskDevice::opticalBlank() const
 {
+    qDebug() << "Checking if disk device is optical blank:" << path();
     return d_ptr->dbus->opticalBlank();
 }
 
 uint DDiskDevice::opticalNumAudioTracks() const
 {
+    qDebug() << "Getting disk device optical number of audio tracks:" << path();
     return d_ptr->dbus->opticalNumAudioTracks();
 }
 
 uint DDiskDevice::opticalNumDataTracks() const
 {
+    qDebug() << "Getting disk device optical number of data tracks:" << path();
     return d_ptr->dbus->opticalNumDataTracks();
 }
 
 uint DDiskDevice::opticalNumSessions() const
 {
+    qDebug() << "Getting disk device optical number of sessions:" << path();
     return d_ptr->dbus->opticalNumSessions();
 }
 
 uint DDiskDevice::opticalNumTracks() const
 {
+    qDebug() << "Getting disk device optical number of tracks:" << path();
     return d_ptr->dbus->opticalNumTracks();
 }
 
 bool DDiskDevice::removable() const
 {
+    qDebug() << "Checking if disk device is removable:" << path();
     return d_ptr->dbus->removable();
 }
 
 QString DDiskDevice::revision() const
 {
+    qDebug() << "Getting disk device revision:" << path();
     return d_ptr->dbus->revision();
 }
 
 int DDiskDevice::rotationRate() const
 {
+    qDebug() << "Getting disk device rotation rate:" << path();
     return d_ptr->dbus->rotationRate();
 }
 
 QString DDiskDevice::seat() const
 {
+    qDebug() << "Getting disk device seat:" << path();
     return d_ptr->dbus->seat();
 }
 
 QString DDiskDevice::serial() const
 {
+    qDebug() << "Getting disk device serial:" << path();
     return d_ptr->dbus->serial();
 }
 
 QString DDiskDevice::siblingId() const
 {
+    qDebug() << "Getting disk device sibling ID:" << path();
     return d_ptr->dbus->siblingId();
 }
 
 qulonglong DDiskDevice::size() const
 {
+    qDebug() << "Getting disk device size:" << path();
     return d_ptr->dbus->size();
 }
 
 QString DDiskDevice::sortKey() const
 {
+    qDebug() << "Getting disk device sort key:" << path();
     return d_ptr->dbus->sortKey();
 }
 
 qulonglong DDiskDevice::timeDetected() const
 {
+    qDebug() << "Getting disk device time detected:" << path();
     return d_ptr->dbus->timeDetected();
 }
 
 qulonglong DDiskDevice::timeMediaDetected() const
 {
+    qDebug() << "Getting disk device time media detected:" << path();
     return d_ptr->dbus->timeMediaDetected();
 }
 
 QString DDiskDevice::vendor() const
 {
+    qDebug() << "Getting disk device vendor:" << path();
     return d_ptr->dbus->vendor();
 }
 
 QString DDiskDevice::WWN() const
 {
+    qDebug() << "Getting disk device WWN:" << path();
     return d_ptr->dbus->wWN();
 }
 
 QDBusError DDiskDevice::lastError() const
 {
     Q_D(const DDiskDevice);
+    qDebug() << "Getting disk device last error:" << path();
     return d->err;
 }
 
 void DDiskDevice::eject(const QVariantMap &options)
 {
     Q_D(DDiskDevice);
-
+    qDebug() << "Ejecting disk device:" << path() << "with options:" << options;
     auto r = d_ptr->dbus->Eject(options);
     r.waitForFinished();
     d->err = r.error();
+    if (r.isError()) {
+        qWarning() << "Failed to eject disk device:" << path() << "error:" << r.error().message();
+    }
 }
 
 void DDiskDevice::powerOff(const QVariantMap &options)
 {
     Q_D(DDiskDevice);
-
+    qDebug() << "Powering off disk device:" << path() << "with options:" << options;
     auto r = d_ptr->dbus->PowerOff(options);
     r.waitForFinished();
     d->err = r.error();
+    if (r.isError()) {
+        qWarning() << "Failed to power off disk device:" << path() << "error:" << r.error().message();
+    }
 }
 
 void DDiskDevice::setConfiguration(const QVariantMap &value, const QVariantMap &options)
 {
     Q_D(DDiskDevice);
-
+    qDebug() << "Setting disk device configuration:" << path() << "value:" << value << "options:" << options;
     auto r = d_ptr->dbus->SetConfiguration(value, options);
     r.waitForFinished();
     d->err = r.error();
+    if (r.isError()) {
+        qWarning() << "Failed to set disk device configuration:" << path() << "error:" << r.error().message();
+    }
 }

--- a/dudisksjob.cpp
+++ b/dudisksjob.cpp
@@ -6,6 +6,7 @@
 #include "udisks2_interface.h"
 
 #include <QDBusConnection>
+#include <QDebug>
 
 class DUDisksJobPrivate
 {
@@ -21,17 +22,20 @@ class DUDisksJobPrivate
 
 DUDisksJob::~DUDisksJob()
 {
+    qDebug() << "DUDisksJob destroyed:" << path();
 }
 
 QString DUDisksJob::path() const
 {
     Q_D(const DUDisksJob);
+    qDebug() << "Getting job path:" << d->dbusif->path();
     return d->dbusif->path();
 }
 
 QStringList DUDisksJob::objects() const
 {
     Q_D(const DUDisksJob);
+    qDebug() << "Getting job objects for path:" << d->dbusif->path();
     QStringList ret;
     for (auto &o : d->dbusif->objects()) {
         ret.push_back(o.path());
@@ -42,61 +46,75 @@ QStringList DUDisksJob::objects() const
 bool DUDisksJob::cancelable() const
 {
     Q_D(const DUDisksJob);
+    qDebug() << "Checking if job is cancelable:" << d->dbusif->path();
     return d->dbusif->cancelable();
 }
 
 bool DUDisksJob::progressValid() const
 {
     Q_D(const DUDisksJob);
+    qDebug() << "Checking if job progress is valid:" << d->dbusif->path();
     return d->dbusif->progressValid();
 }
 
 double DUDisksJob::progress() const
 {
     Q_D(const DUDisksJob);
+    qDebug() << "Getting job progress:" << d->dbusif->path() << "progress:" << d->dbusif->progress();
     return d->dbusif->progress();
 }
 
 QString DUDisksJob::operation() const
 {
     Q_D(const DUDisksJob);
+    qDebug() << "Getting job operation:" << d->dbusif->path() << "operation:" << d->dbusif->operation();
     return d->dbusif->operation();
 }
 
 quint32 DUDisksJob::startedByUid() const
 {
     Q_D(const DUDisksJob);
+    qDebug() << "Getting job started by UID:" << d->dbusif->path();
     return d->dbusif->startedByUID();
 }
 
 quint64 DUDisksJob::bytes() const
 {
     Q_D(const DUDisksJob);
+    qDebug() << "Getting job bytes:" << d->dbusif->path() << "bytes:" << d->dbusif->bytes();
     return d->dbusif->bytes();
 }
 
 quint64 DUDisksJob::expectedEndTime() const
 {
     Q_D(const DUDisksJob);
+    qDebug() << "Getting job expected end time:" << d->dbusif->path();
     return d->dbusif->expectedEndTime();
 }
 
 quint64 DUDisksJob::rate() const
 {
     Q_D(const DUDisksJob);
+    qDebug() << "Getting job rate:" << d->dbusif->path() << "rate:" << d->dbusif->rate();
     return d->dbusif->rate();
 }
 
 quint64 DUDisksJob::startTime() const
 {
     Q_D(const DUDisksJob);
+    qDebug() << "Getting job start time:" << d->dbusif->path();
     return d->dbusif->startTime();
 }
 
 void DUDisksJob::cancel(const QVariantMap &options)
 {
     Q_D(DUDisksJob);
-    d->dbusif->Cancel(options).waitForFinished();
+    qDebug() << "Cancelling job:" << d->dbusif->path() << "with options:" << options;
+    auto r = d->dbusif->Cancel(options);
+    r.waitForFinished();
+    if (r.isError()) {
+        qWarning() << "Failed to cancel job:" << d->dbusif->path() << "error:" << r.error().message();
+    }
 }
 
 DUDisksJob::DUDisksJob(QString path, QObject *parent)
@@ -104,6 +122,7 @@ DUDisksJob::DUDisksJob(QString path, QObject *parent)
     , d_ptr(new DUDisksJobPrivate(this))
 {
     Q_D(DUDisksJob);
+    qDebug() << "Creating DUDisksJob for path:" << path;
     d->dbusif = new OrgFreedesktopUDisks2JobInterface(UDISKS2_SERVICE, path, QDBusConnection::systemBus());
     QDBusConnection::systemBus().connect(UDISKS2_SERVICE, d->dbusif->path(), "org.freedesktop.DBus.Properties",
                    "PropertiesChanged", this, SLOT(onPropertiesChanged(const QString &, const QVariantMap &)));
@@ -113,6 +132,7 @@ DUDisksJob::DUDisksJob(QString path, QObject *parent)
 void DUDisksJob::onPropertiesChanged(const QString &interface, const QVariantMap &changed_properties)
 {
     Q_UNUSED(interface)
+    qDebug() << "Properties changed for job:" << d_ptr->dbusif->path() << "interface:" << interface;
 
     auto begin = changed_properties.begin();
 

--- a/udisks2_dbus_common.cpp
+++ b/udisks2_dbus_common.cpp
@@ -11,6 +11,7 @@
 #include <QDBusConnection>
 #include <QDBusReply>
 #include <QXmlStreamReader>
+#include <QDebug>
 
 namespace UDisks2 {
 Q_GLOBAL_STATIC_WITH_ARGS(OrgFreedesktopDBusObjectManagerInterface, omGlobal, (UDISKS2_SERVICE, "/org/freedesktop/UDisks2", QDBusConnection::systemBus()))
@@ -18,6 +19,7 @@ Q_GLOBAL_STATIC_WITH_ARGS(OrgFreedesktopUDisks2ManagerInterface, umGlobal, (UDIS
 
 bool interfaceExists(const QString &path, const QString &interface)
 {
+    qDebug() << "Checking if interface exists:" << interface << "for path:" << path;
     QDBusInterface ud2(UDISKS2_SERVICE, path, "org.freedesktop.DBus.Introspectable", QDBusConnection::systemBus());
     QDBusReply<QString> reply = ud2.call("Introspect");
     QXmlStreamReader xml_parser(reply.value());
@@ -30,17 +32,21 @@ bool interfaceExists(const QString &path, const QString &interface)
             const QString &name = xml_parser.attributes().value("name").toString();
 
             if (name == interface) {
+                qDebug() << "Interface found:" << interface;
                 return true;
             }
         }
     }
 
+    qDebug() << "Interface not found:" << interface;
     return false;
 }
 
 OrgFreedesktopDBusObjectManagerInterface *objectManager()
 {
+    qDebug() << "Getting UDisks2 object manager";
     if (!omGlobal.exists()) {
+        qDebug() << "Registering DBus meta types";
         qDBusRegisterMetaType<QMap<QString, QVariantMap>>();
         qDBusRegisterMetaType<QList<QPair<QString, QVariantMap>>>();
         qDBusRegisterMetaType<QByteArrayList>();
@@ -53,11 +59,13 @@ OrgFreedesktopDBusObjectManagerInterface *objectManager()
 
 QString version()
 {
+    qDebug() << "Getting UDisks2 version";
     return umGlobal->version();
 }
 
 QStringList supportedFilesystems()
 {
+    qDebug() << "Getting UDisks2 supported filesystems";
     return umGlobal->supportedFilesystems();
 }
 
@@ -65,6 +73,7 @@ QStringList supportedFilesystems()
 
 QDBusArgument &operator<<(QDBusArgument &argument, const UDisks2::SmartAttribute &mystruct)
 {
+    qDebug() << "Serializing SmartAttribute to DBus argument";
     argument.beginStructure();
     argument << mystruct.id
              << mystruct.name
@@ -82,6 +91,7 @@ QDBusArgument &operator<<(QDBusArgument &argument, const UDisks2::SmartAttribute
 
 const QDBusArgument &operator>>(const QDBusArgument &argument, UDisks2::SmartAttribute &mystruct)
 {
+    qDebug() << "Deserializing SmartAttribute from DBus argument";
     argument.beginStructure();
     argument >> mystruct.id
             >> mystruct.name
@@ -99,6 +109,7 @@ const QDBusArgument &operator>>(const QDBusArgument &argument, UDisks2::SmartAtt
 
 QDBusArgument &operator<<(QDBusArgument &argument, const UDisks2::ActiveDeviceInfo &mystruct)
 {
+    qDebug() << "Serializing ActiveDeviceInfo to DBus argument";
     argument.beginStructure();
     argument << mystruct.block
              << mystruct.slot
@@ -112,6 +123,7 @@ QDBusArgument &operator<<(QDBusArgument &argument, const UDisks2::ActiveDeviceIn
 
 const QDBusArgument &operator>>(const QDBusArgument &argument, UDisks2::ActiveDeviceInfo &mystruct)
 {
+    qDebug() << "Deserializing ActiveDeviceInfo from DBus argument";
     argument.beginStructure();
     argument >> mystruct.block
             >> mystruct.slot


### PR DESCRIPTION
- Introduced qDebug() statements to track object creation, property changes, and method calls.
- Enhanced error handling with qWarning() for failed operations.
- Improved traceability of operations related to block devices and partitions.

Log: add log